### PR TITLE
Temporal fix to append pack size to batch info

### DIFF
--- a/src/core/api/types/stockItem/StockBatchDTO.ts
+++ b/src/core/api/types/stockItem/StockBatchDTO.ts
@@ -1,3 +1,5 @@
+import { StockItem } from "./StockItem";
+
 export interface StockBatchDTO {
   uuid: string;
   batchNo: string;
@@ -6,5 +8,7 @@ export interface StockBatchDTO {
   quantity: string;
   quantityFactor: string;
   quantityUoM: string;
+  packagingUomFactor?: string;
+  packagingUomName?: string;
   voided: boolean;
 }


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
We need away to show pack size information along side batch info. We should enhance the model to establish direct connection between the two. Right now, this is missing hence the temporal hack herein.

## Screenshots
<!-- Required if you are making UI changes. -->

![Screenshot from 2024-08-22 16-55-14](https://github.com/user-attachments/assets/f156a8d0-a652-4409-a47c-7e8c150e075e)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
