### PR TITLE
 KHP3-8063: (feat) Add separate positive/negative adjustment reasons functionality

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -30,6 +30,16 @@ export const configSchema = {
     _description: 'UUID for the stock adjustment reasons',
     _default: '3bbfaa44-d5b8-404d-b4c1-2bf49ad8ce25',
   },
+  stockNegativeReasonUuid: {
+    _type: Type.ConceptUuid,
+    _description: 'UUID for the stock negative reasons',
+    _default: '37123baa-e890-4337-b630-bf5cac9ed9d5',
+  },
+  stockPositiveReasonUuid: {
+    _type: Type.ConceptUuid,
+    _description: 'UUID for the stock positive reasons',
+    _default: '3bbfaa44-d5b8-404d-b4c1-2bf49ad8ce25',
+  },
   stockTakeReasonUUID: {
     _type: Type.ConceptUuid,
     _description: 'UUID for the stock take reasons',
@@ -81,6 +91,8 @@ export type ConfigObject = {
   printBalanceOnHand: boolean;
   packagingUnitsUUID: string;
   stockAdjustmentReasonUUID: string;
+  stockNegativeReasonUuid: string;
+  stockPositiveReasonUuid: string;
   stockSourceTypeUUID: string;
   dispensingUnitsUUID: string;
   stockItemCategoryUUID: string;

--- a/src/stock-operations/stock-operation-types-selector/stock-operation-types-selector.component.tsx
+++ b/src/stock-operations/stock-operation-types-selector/stock-operation-types-selector.component.tsx
@@ -7,6 +7,10 @@ import { OperationType, type StockOperationType } from '../../core/api/types/sto
 import { launchStockoperationAddOrEditWorkSpace } from '../stock-operation.utils';
 import useFilteredOperationTypesByRoles from '../stock-operations-forms/hooks/useFilteredOperationTypesByRoles';
 
+interface ExtendedStockOperationType extends StockOperationType {
+  adjustmentType?: 'positive' | 'negative';
+}
+
 const StockOperationTypesSelector = () => {
   const { t } = useTranslation();
   const { error, isLoading, operationTypes } = useFilteredOperationTypesByRoles();
@@ -19,19 +23,19 @@ const StockOperationTypesSelector = () => {
   const transformedOperationTypes = useMemo(() => {
     return operationTypes
       .filter((operation) => operation.operationType !== OperationType.STOCK_ISSUE_OPERATION_TYPE)
-      .flatMap((operation) => {
+      .flatMap((operation): ExtendedStockOperationType[] => {
         if (operation.operationType === 'adjustment') {
           return [
-            { ...operation, name: 'Negative Adjustment' },
-            { ...operation, name: 'Positive Adjustment' },
+            { ...operation, name: 'Negative Adjustment', adjustmentType: 'negative' },
+            { ...operation, name: 'Positive Adjustment', adjustmentType: 'positive' },
           ];
         }
-        return operation;
+        return [operation];
       });
   }, [operationTypes]);
 
   const handleSelect = useCallback(
-    (stockOperationType: StockOperationType) => {
+    (stockOperationType: ExtendedStockOperationType) => {
       const isStockIssueOperation = stockOperationType.operationType === OperationType.STOCK_ISSUE_OPERATION_TYPE;
 
       launchStockoperationAddOrEditWorkSpace(t, stockOperationType, undefined);
@@ -77,7 +81,7 @@ const StockOperationTypesSelector = () => {
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((operation) => (
           <OverflowMenuItem
-            key={operation.uuid}
+            key={`${operation.uuid}-${operation.adjustmentType || 'default'}`}
             itemText={operation.name}
             onClick={() => {
               handleSelect(operation);

--- a/src/stock-operations/stock-operations-forms/steps/base-operation-details-form-step.tsx
+++ b/src/stock-operations/stock-operations-forms/steps/base-operation-details-form-step.tsx
@@ -25,9 +25,12 @@ import StockOperationReasonSelector from '../input-components/stock-operation-re
 import UsersSelector from '../input-components/users-selector.component';
 import styles from '../stock-operation-form.scss';
 
+interface ExtendedStockOperationType extends StockOperationType {
+  adjustmentType?: 'positive' | 'negative';
+}
 type BaseOperationDetailsFormStepProps = {
   stockOperation?: StockOperationDTO;
-  stockOperationType: StockOperationType;
+  stockOperationType: ExtendedStockOperationType;
   onNext?: () => void;
 };
 
@@ -223,7 +226,10 @@ const BaseOperationDetailsFormStep: FC<BaseOperationDetailsFormStepProps> = ({
       <UsersSelector />
       {operationTypePermision.requiresStockAdjustmentReason && (
         <Column>
-          <StockOperationReasonSelector stockOperationType={stockOperationType?.operationType} />
+          <StockOperationReasonSelector
+            stockOperationType={stockOperationType?.operationType}
+            adjustmentType={stockOperationType?.adjustmentType}
+          />
         </Column>
       )}
       <Column>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR implements separate positive and negative adjustment reasons functionality for stock operations, allowing for more granular control and better categorization of stock adjustments.

## Screenshots
<!-- Required if you are making UI changes. -->
![adjustment-positive-negative](https://github.com/user-attachments/assets/162b7e96-8571-43cb-a550-9bb587960965)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
